### PR TITLE
Fixed index out of range error in level 2

### DIFF
--- a/Mobile Defense/Assets/Scenes/Level_2.unity
+++ b/Mobile Defense/Assets/Scenes/Level_2.unity
@@ -12056,7 +12056,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58e35a1b20d9e714495e21bd4be04314, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  enemy: {fileID: 8436659280349849175, guid: c118c14344409d34a82a8b26eb7147db, type: 3}
+  waves:
+  - enemy: {fileID: 8436659280349849175, guid: c118c14344409d34a82a8b26eb7147db, type: 3}
+    count: 3
+    spawnRate: 1
   endNode: {fileID: 892138086}
   spawnPoint: {fileID: 1641169139}
   waveCount: {fileID: 265580837}

--- a/Mobile Defense/Assets/Scripts/Director.cs
+++ b/Mobile Defense/Assets/Scripts/Director.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Linq;
+using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -86,7 +87,19 @@ public class Director : MonoBehaviour
 
         //set the current wave. If we've reached
         //the end of the wave list, default to the first wave
-        Wave wave = waveIndex < waves.Length ? waves[waveIndex] : waves[0];
+        Wave wave;
+        if (waves.Length > 0)
+        {
+            if (waveIndex < waves.Length) wave = waves[waveIndex];
+            else wave = waves[0];
+        }
+        //if no waves are defined, this warning will display
+        else
+        {
+            Debug.LogWarning("Warning: The director has no waves defined! " +
+            "You can create waves for the director in the inspector");
+            yield break;
+        }
 
         for (int i = 0; i < wave.count; i++)
         {


### PR DESCRIPTION
Note that this error was created because level 2 had no waves defined in the director. I added error handling that should inform you if the director has no waves defined